### PR TITLE
新增外掛 WP Better Permalinks

### DIFF
--- a/plugins_list.json
+++ b/plugins_list.json
@@ -20,6 +20,13 @@
     "dlink": "",
     "version": ""
 }, {
+    "name": "WP Better Permalinks",
+    "slug": "wp-better-permalinks",
+    "hosted": "wordpress.org",
+    "description": "可為網站設定更容易檢索的自訂永久連結，製作出 /post_type/term/post_name 的永久連結結構。",
+    "dlink": "",
+    "version": ""
+}, {
     "name": "User Role Editor",
     "slug": "user-role-editor",
     "hosted": "wordpress.org",


### PR DESCRIPTION
新增 WP Better Permalinks 外掛，製作做更友善合宜的永久連結架構。
跟原本的 /taxonomy/term/ 這種醜醜的網址結構說再見 XD